### PR TITLE
Fix name of executable

### DIFF
--- a/docs/13_rajaperf/rajaperf.rst
+++ b/docs/13_rajaperf/rajaperf.rst
@@ -329,8 +329,8 @@ To get information about how to run the code, use the *help option*::
   path/to/RAJAPerf
   $ cd my-build
   $ ls bin
-  rajaperf.exe
-  $ ./bin/rajaperf.exe --help (or -h)
+  raja-perf.exe
+  $ ./bin/raja-perf.exe --help (or -h)
 
 This will print all available command-line options along with potential
 arguments and defaults. Available options allow one to print information about


### PR DESCRIPTION
This PR addresses the issues with the RAJAPerf documentation that @rfhaque pointed out. In particular, it fixes the name of the executable.

It turns out that the version information in the docs `v2026.04.1` was correct. I had that release staged and forgot to hit the "publish" button.